### PR TITLE
feat: install Radix icons and configure it as external component library

### DIFF
--- a/codux-external-components.json
+++ b/codux-external-components.json
@@ -1,42 +1,42 @@
-[  
-    {
-        "name": "Radix Icons",
-        "components": [
-            {
-                "filePath": "@radix-ui/react-icons",
-                "exportName": "MagnifyingGlassIcon",
-                "name": "Magnifying Glass"
-            },
-            {
-                "filePath": "@radix-ui/react-icons",
-                "exportName": "DrawingPinFilledIcon",
-                "name": "Drawing Pin Filled"
-            },
-            {
-                "filePath": "@radix-ui/react-icons",
-                "exportName": "DrawingPinIcon",
-                "name": "Drawing Pin"
-            },
-            {
-                "filePath": "@radix-ui/react-icons",
-                "exportName": "DotsVerticalIcon",
-                "name": "Dots Vertical"
-            },
-            {
-                "filePath": "@radix-ui/react-icons",
-                "exportName": "PlusIcon",
-                "name": "Plus"
-            },
-            {
-                "filePath": "@radix-ui/react-icons",
-                "exportName": "TrashIcon",
-                "name": "Trash"
-            },
-            {
-                "filePath": "@radix-ui/react-icons",
-                "exportName": "ReaderIcon",
-                "name": "Reader"
-            }
-        ]
-    }
+[
+  {
+    "name": "Radix Icons",
+    "components": [
+      {
+        "filePath": "@radix-ui/react-icons",
+        "exportName": "MagnifyingGlassIcon",
+        "name": "Magnifying Glass"
+      },
+      {
+        "filePath": "@radix-ui/react-icons",
+        "exportName": "DrawingPinFilledIcon",
+        "name": "Drawing Pin Filled"
+      },
+      {
+        "filePath": "@radix-ui/react-icons",
+        "exportName": "DrawingPinIcon",
+        "name": "Drawing Pin"
+      },
+      {
+        "filePath": "@radix-ui/react-icons",
+        "exportName": "DotsVerticalIcon",
+        "name": "Dots Vertical"
+      },
+      {
+        "filePath": "@radix-ui/react-icons",
+        "exportName": "PlusIcon",
+        "name": "Plus"
+      },
+      {
+        "filePath": "@radix-ui/react-icons",
+        "exportName": "TrashIcon",
+        "name": "Trash"
+      },
+      {
+        "filePath": "@radix-ui/react-icons",
+        "exportName": "ReaderIcon",
+        "name": "Reader"
+      }
+    ]
+  }
 ]

--- a/codux-external-components.json
+++ b/codux-external-components.json
@@ -5,37 +5,37 @@
             {
                 "filePath": "@radix-ui/react-icons",
                 "exportName": "MagnifyingGlassIcon",
-                "name": "MagnifyingGlassIcon"
+                "name": "Magnifying Glass"
             },
             {
                 "filePath": "@radix-ui/react-icons",
                 "exportName": "DrawingPinFilledIcon",
-                "name": "DrawingPinFilledIcon"
+                "name": "Drawing Pin Filled"
             },
             {
                 "filePath": "@radix-ui/react-icons",
                 "exportName": "DrawingPinIcon",
-                "name": "DrawingPinIcon"
+                "name": "Drawing Pin"
             },
             {
                 "filePath": "@radix-ui/react-icons",
                 "exportName": "DotsVerticalIcon",
-                "name": "DotsVerticalIcon"
+                "name": "Dots Vertical"
             },
             {
                 "filePath": "@radix-ui/react-icons",
                 "exportName": "PlusIcon",
-                "name": "PlusIcon"
+                "name": "Plus"
             },
             {
                 "filePath": "@radix-ui/react-icons",
                 "exportName": "TrashIcon",
-                "name": "TrashIcon"
+                "name": "Trash"
             },
             {
                 "filePath": "@radix-ui/react-icons",
                 "exportName": "ReaderIcon",
-                "name": "ReaderIcon"
+                "name": "Reader"
             }
         ]
     }

--- a/codux-external-components.json
+++ b/codux-external-components.json
@@ -1,0 +1,42 @@
+[  
+    {
+        "name": "Radix Icons",
+        "components": [
+            {
+                "filePath": "@radix-ui/react-icons",
+                "exportName": "MagnifyingGlassIcon",
+                "name": "MagnifyingGlassIcon"
+            },
+            {
+                "filePath": "@radix-ui/react-icons",
+                "exportName": "DrawingPinFilledIcon",
+                "name": "DrawingPinFilledIcon"
+            },
+            {
+                "filePath": "@radix-ui/react-icons",
+                "exportName": "DrawingPinIcon",
+                "name": "DrawingPinIcon"
+            },
+            {
+                "filePath": "@radix-ui/react-icons",
+                "exportName": "DotsVerticalIcon",
+                "name": "DotsVerticalIcon"
+            },
+            {
+                "filePath": "@radix-ui/react-icons",
+                "exportName": "PlusIcon",
+                "name": "PlusIcon"
+            },
+            {
+                "filePath": "@radix-ui/react-icons",
+                "exportName": "TrashIcon",
+                "name": "TrashIcon"
+            },
+            {
+                "filePath": "@radix-ui/react-icons",
+                "exportName": "ReaderIcon",
+                "name": "ReaderIcon"
+            }
+        ]
+    }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "notes-app",
       "version": "1.0.0",
       "dependencies": {
+        "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/themes": "^3.0.3",
         "@types/node": "^20.12.7",
         "classnames": "^2.5.1",
@@ -1303,6 +1304,14 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.0.tgz",
+      "integrity": "sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x"
       }
     },
     "node_modules/@radix-ui/react-id": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/themes": "^3.0.3",
     "@types/node": "^20.12.7",
     "classnames": "^2.5.1",


### PR DESCRIPTION
Install `@radix-ui/react-icons` and create `codux-external-components.json` with Radix icons as the external component library.

<img width="448" alt="Screenshot 2024-05-09 at 16 37 28" src="https://github.com/wixplosives/NotesApp/assets/31585545/57f973e2-3838-4e79-b4ea-7bc3a6e7797c">
