### PR TITLE
feat: Toast component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-separator": "^1.0.3",
+        "@radix-ui/react-toast": "^1.1.5",
         "@radix-ui/react-toggle": "^1.0.3",
         "@radix-ui/react-toggle-group": "^1.0.4",
         "@radix-ui/themes": "^3.0.3",
@@ -1918,6 +1919,40 @@
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-roving-focus": "1.0.4",
         "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.1.5.tgz",
+      "integrity": "sha512-fRLn227WHIBRSzuRzGJ8W+5YALxofH23y0MlPLddaIpLpCDqdE0NZlS2NRQDRiptfxDeeCjgFIpexB1/zkxDlw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-separator": "^1.0.3",
+    "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-toggle": "^1.0.3",
     "@radix-ui/react-toggle-group": "^1.0.4",
     "@radix-ui/themes": "^3.0.3",

--- a/src/_codux/boards/toast-viewport/toast-viewport.board.tsx
+++ b/src/_codux/boards/toast-viewport/toast-viewport.board.tsx
@@ -1,0 +1,13 @@
+import { createBoard } from '@wixc3/react-board';
+import { ToastViewport } from '../../../components/toast-viewport/toast-viewport';
+import * as RadixToast from '@radix-ui/react-toast';
+
+export default createBoard({
+    name: 'ToastViewport',
+    Board: () => (
+        <RadixToast.Provider>
+            <ToastViewport />
+        </RadixToast.Provider>
+    ),
+    isSnippet: false,
+});

--- a/src/_codux/boards/toast/toast-with-trigger.board.tsx
+++ b/src/_codux/boards/toast/toast-with-trigger.board.tsx
@@ -1,0 +1,32 @@
+import { ContentSlot, createBoard } from '@wixc3/react-board';
+import { Toast } from '../../../components/toast/toast';
+import * as RadixToast from '@radix-ui/react-toast';
+import { useState } from 'react';
+import { Button } from '../../../components/button/button';
+import { ToastViewport } from '../../../components/toast-viewport/toast-viewport';
+
+export default createBoard({
+    name: 'Toast With Trigger',
+    Board: () => {
+        const [open, setOpen] = useState(false);
+
+        return (
+            <RadixToast.Provider>
+                <ContentSlot>
+                    <>
+                        <Button onClick={() => setOpen(true)}>Open Toast</Button>
+                        <Toast
+                            title="Note moved to Trash"
+                            description="It didn't delete permanently"
+                            open={open}
+                            onOpenChange={setOpen}
+                            action={<Button>Undo</Button>}
+                        />
+                    </>
+                </ContentSlot>
+                <ToastViewport />
+            </RadixToast.Provider>
+        );
+    },
+    isSnippet: true,
+});

--- a/src/_codux/boards/toast/toast.board.tsx
+++ b/src/_codux/boards/toast/toast.board.tsx
@@ -1,0 +1,34 @@
+import { ContentSlot, createBoard } from '@wixc3/react-board';
+import { Toast } from '../../../components/toast/toast';
+import * as RadixToast from '@radix-ui/react-toast';
+import { Button } from '../../../components/button/button';
+import { useState } from 'react';
+
+export default createBoard({
+    name: 'Toast',
+    Board: () => {
+        const [open, setOpen] = useState(false);
+        return (
+            <RadixToast.Provider>
+                <ContentSlot>
+                    <Toast
+                        title="Toast title"
+                        description="Toast description"
+                        action={<Button>Action</Button>}
+                        open={true}
+                    />
+                </ContentSlot>
+                <RadixToast.Viewport />
+            </RadixToast.Provider>
+        );
+    },
+    isSnippet: true,
+    environmentProps: {
+        canvasPadding: {
+            top: 50,
+            right: 50,
+            bottom: 50,
+            left: 50,
+        },
+    },
+});

--- a/src/components/toast-viewport/toast-viewport.module.scss
+++ b/src/components/toast-viewport/toast-viewport.module.scss
@@ -1,0 +1,16 @@
+.root {
+    --viewport-padding: 25px;
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    padding: var(--viewport-padding);
+    gap: 10px;
+    width: 400px;
+    max-width: 100vw;
+    margin: 0;
+    list-style: none;
+    z-index: 2147483647;
+    outline: none;
+}

--- a/src/components/toast-viewport/toast-viewport.tsx
+++ b/src/components/toast-viewport/toast-viewport.tsx
@@ -1,0 +1,11 @@
+import classNames from 'classnames';
+import styles from './toast-viewport.module.scss';
+import * as RadixToast from '@radix-ui/react-toast';
+
+export interface ToastViewportProps {
+    className?: string;
+}
+
+export const ToastViewport = ({ className }: ToastViewportProps) => {
+    return <RadixToast.Viewport className={classNames(styles.root, className)} />;
+};

--- a/src/components/toast/toast.module.scss
+++ b/src/components/toast/toast.module.scss
@@ -1,0 +1,79 @@
+@import '../../styles/common/variables.module.scss';
+.root {
+    width: 350px;
+    border-radius: 6px;
+    padding: 15px;
+    display: grid;
+    grid-template-rows: auto auto;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    column-gap: 10px;
+    background-color: $sand1;
+    border: 1px solid $sand2;
+    box-shadow:
+        0 10px 20px -15px rgba(14, 18, 22, 0.2),
+        0 10px 38px -10px rgba(13, 18, 22, 0.35);
+}
+.action {
+    grid-row: 1 / 3;
+    grid-column: 2 / 3;
+}
+.title {
+    font-size: 15px;
+    font-weight: 700;
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+}
+.description {
+    font-size: 13px;
+    grid-row: 2 / 3;
+    grid-column: 1 / 2;
+}
+
+.root[data-state='open'] {
+    animation: slideIn 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.root[data-state='closed'] {
+    animation: hide 100ms ease-in;
+}
+
+.root[data-swipe='move'] {
+    transform: translateX(var(--radix-toast-swipe-move-x));
+}
+
+.root[data-swipe='cancel'] {
+    transform: translateX(0);
+    transition: transform 200ms ease-out;
+}
+
+.root[data-swipe='end'] {
+    animation: swipeOut 100ms ease-out;
+}
+
+@keyframes hide {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateX(calc(100% + var(--viewport-padding)));
+    }
+    to {
+        transform: translateX(0);
+    }
+}
+
+@keyframes swipeOut {
+    from {
+        transform: translateX(var(--radix-toast-swipe-end-x));
+    }
+    to {
+        transform: translateX(calc(100% + var(--viewport-padding)));
+    }
+}

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -1,0 +1,37 @@
+import classNames from 'classnames';
+import styles from './toast.module.scss';
+import * as RadixToast from '@radix-ui/react-toast';
+
+export interface ToastProps {
+    title: string;
+    description: string;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    className?: string;
+    action?: React.ReactNode;
+    actionAltText?: string;
+}
+
+export const Toast = ({
+    title,
+    description,
+    open,
+    onOpenChange,
+    className,
+    action,
+    actionAltText,
+}: ToastProps) => {
+    return (
+        <RadixToast.Root open={open} onOpenChange={onOpenChange} className={classNames(styles.root, className)}>
+            <RadixToast.Title className={styles.title}>{title}</RadixToast.Title>
+            <RadixToast.Description className={styles.description}>
+                {description}
+            </RadixToast.Description>
+            {action && (
+                <RadixToast.Action asChild altText={actionAltText ?? 'Action'} className={styles.action}>
+                    {action}
+                </RadixToast.Action>
+            )}
+        </RadixToast.Root>
+    );
+};


### PR DESCRIPTION
Create a Toast component based on Radix Toast primitives.
Includes 2 boards:
- `Toast` board to style the toast component itself;
- `Toast With Toggle` board which is a button that opens a toast. This is to see how toast opens and hides in action.

This is not complete to be used in the app. Next, I plan to create a container for all app toasts and a simple global store with `zustand` to manage them. Nothing too fancy as it is solely developer-wise.

<img width="527" alt="Screenshot 2024-05-15 at 14 14 21" src="https://github.com/wixplosives/NotesApp/assets/31585545/5ea6174d-6508-4cf7-b6a9-6f4dd0d08567">
<img width="1092" alt="Screenshot 2024-05-15 at 14 14 41" src="https://github.com/wixplosives/NotesApp/assets/31585545/0cdc7c0a-7d3c-4184-81bc-9940137bd934">

