### PR TITLE
fix: deserialize note dates

### DIFF
--- a/src/data-management/local-storage/local-storage-service.ts
+++ b/src/data-management/local-storage/local-storage-service.ts
@@ -6,7 +6,19 @@ export class LocalStorageService implements StorageService {
     async getAllNotes(): Promise<Note[]> {
         return new Promise((resolve) => {
             const notesData = localStorage.getItem(STORAGE_NOTES_KEY);
-            resolve(notesData ? JSON.parse(notesData) : []);
+            if (notesData) {
+                const notes = JSON.parse(notesData);
+                for (const note of notes) {
+                    note.createdAt = new Date(note.createdAt);
+                    note.modifiedAt = new Date(note.modifiedAt);
+                    if (note.deletedAt) {
+                        note.deletedAt = new Date(note.deletedAt);
+                    }
+                }
+                resolve(notes);
+            } else {
+                resolve([]);
+            }
         });
     }
 


### PR DESCRIPTION
We blindly specify the type of `JSON.parse(notesData)` to be `Note[]`. Which is not true. We keep notes in local storage, thus dates are serialized. So, TS believes `createdAt` is a `Date`, while in fact it is a `string`.

To keep it simple I've manually converted dates to the correct representation.